### PR TITLE
[Fix] 레디스 설정 클래스 복구 및 URI 분리

### DIFF
--- a/backend/src/main/java/com/example/backend/config/RedissonConfig.java
+++ b/backend/src/main/java/com/example/backend/config/RedissonConfig.java
@@ -1,0 +1,61 @@
+package com.example.backend.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.time.Duration;
+
+@Configuration
+public class RedissonConfig {
+
+
+    private final Environment env;
+
+    public RedissonConfig(Environment env) {
+        this.env = env;
+    }
+
+
+    @Value("${spring.redis.password:}")
+    private String redisPassword;
+
+    @Value("${spring.redis.timeout}")
+    private Duration timeout;
+
+    @Value("${spring.redis.connect-timeout}")
+    private Duration connectTimeout;
+
+    @Value("${spring.redis.lettuce.pool.max-active}")
+    private int poolSize;
+
+    @Value("${spring.redis.lettuce.pool.min-idle}")
+    private int minIdle;
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        try {
+            String[] nodeAddresses = env.getProperty("clusterServersConfig.nodeAddresses", String[].class);
+
+            if (nodeAddresses == null || nodeAddresses.length == 0) {
+                System.err.println("⚠️ spring.redis.cluster.nodes 설정이 없어서 Redis 연결을 생략합니다.");
+                return null;
+            }
+            Config config = new Config();
+            config.setNettyThreads(32);
+            config.useClusterServers()
+                    .addNodeAddress( nodeAddresses )
+                    .setPassword(redisPassword.isEmpty() ? null : redisPassword)
+                    .setScanInterval(2000);;
+
+            return Redisson.create(config);
+        } catch (Exception e) {
+            System.err.println("⚠️ Redisson 연결 실패: " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
     name: techup-backend
   redis:
     cluster:
+      max-redirects: 3
       nodes:
         - redis-cluster-0.redis-cluster.default.svc.cluster.local:6379
         - redis-cluster-1.redis-cluster.default.svc.cluster.local:6379
@@ -127,3 +128,9 @@ elasticsearch:
   host: ${ELASTIC_HOST}
   username: elastic
   password: changeme
+
+clusterServersConfig:
+  nodeAddresses:
+    - redis://redis-cluster-0.redis-cluster.default.svc.cluster.local:6379
+    - redis://redis-cluster-1.redis-cluster.default.svc.cluster.local:6379
+    - redis://redis-cluster-2.redis-cluster.default.svc.cluster.local:6379


### PR DESCRIPTION
Redisson과 Spring Data Redis의 차이:

클러스터 노드에 접근할 때 Spring Data Redis는 'redis://'이 안 붙고, Redisson은 붙는다.