### PR TITLE
[Fix] 제품 목록 - 응답 DTO 간소화 버전으로 전환

### DIFF
--- a/backend/src/main/java/com/example/backend/product/controller/ProductController.java
+++ b/backend/src/main/java/com/example/backend/product/controller/ProductController.java
@@ -38,7 +38,7 @@ public class ProductController {
 
     @Operation(summary = "상품 리스트 조회 (paged)", description = "페이지 단위로 상품 리스트를 조회합니다.")
     @GetMapping("/list")
-    public BaseResponse<Page<ProductResponseDto>> getProductList(
+    public BaseResponse<Page<ReducedProductResponseDto>> getProductList(
             @RequestParam(defaultValue = "") String category,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "30") int size
@@ -46,10 +46,10 @@ public class ProductController {
         Pageable pageable = PageRequest.of(page, size);
         log.info("listing category {}", category);
         if (category == null || category.isBlank() || category.equals("ALL")) {
-            Page<ProductResponseDto> dtos = productService.getProductList(pageable);
+            Page<ReducedProductResponseDto> dtos = productService.getProductList(pageable);
             return baseResponseService.getSuccessResponse(dtos, ProductResponseStatus.SUCCESS);
         } else {
-            Page<ProductResponseDto> dtos = productService.getProductList(category, pageable);
+            Page<ReducedProductResponseDto> dtos = productService.getProductList(category, pageable);
             return baseResponseService.getSuccessResponse(dtos, ProductResponseStatus.SUCCESS);
         }
     }

--- a/backend/src/main/java/com/example/backend/product/model/dto/ReducedProductResponseDto.java
+++ b/backend/src/main/java/com/example/backend/product/model/dto/ReducedProductResponseDto.java
@@ -31,9 +31,15 @@ public class ReducedProductResponseDto {
     private Double rating;
 
     @Schema(description = "등록한 첫번째 이미지를 불러옵니다. 앞에 http: 또는 https:가 생략되어 있으니 주의해야 합니다.", example="//image.danawa.com/12")
-    private String image;
+    private List<String> image;
+
+    @Schema(description = "누적 리뷰 수를 불러옵니다", example="2")
+    private Integer reviews;
+
 
     public static ReducedProductResponseDto from(ProductIndexDocument product) {
+        List<String> images = new ArrayList<>();
+        images.add(product.getImage());
         return ReducedProductResponseDto.builder()
                 .idx(product.getProductidx())
                 .name(product.getProductname())
@@ -44,7 +50,27 @@ public class ReducedProductResponseDto {
                 .description(product.getDescription())
                 .category(product.getCategory())
                 .rating(product.getRating())
-                .image(product.getImage())
+                .image(images)
+                .reviews(product.getReviews())
+                .build();
+    }
+    public static ReducedProductResponseDto from(Product product) {
+        List<String> images = new ArrayList<>();
+        if (product.getImages() != null) {
+            images.add(product.getImages().get(0).getImageUrl());
+        }
+        return ReducedProductResponseDto.builder()
+                .idx(product.getProductIdx())
+                .name(product.getName())
+                .price(product.getPrice())
+                .discount(product.getDiscount())
+                .brand(product.getBrand())
+                .stock(product.getStock())
+                .description(product.getDescription())
+                .category(product.getCategory())
+                .rating(product.getRating())
+                .image(images)
+                .reviews(product.getReviews().size())
                 .build();
     }
 }

--- a/backend/src/main/java/com/example/backend/product/service/ProductService.java
+++ b/backend/src/main/java/com/example/backend/product/service/ProductService.java
@@ -50,14 +50,14 @@ public class ProductService {
     private final ProductImageService productImageService;
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public Page<ProductResponseDto> getProductList(Pageable pageable) {
+    public Page<ReducedProductResponseDto> getProductList(Pageable pageable) {
         return productRepository.findAll(pageable)
-                .map(ProductResponseDto::from);
+                .map(ReducedProductResponseDto::from);
     }
 
-    public Page<ProductResponseDto> getProductList(String category, Pageable pageable) {
+    public Page<ReducedProductResponseDto> getProductList(String category, Pageable pageable) {
         return productRepository.findAllByCategoryIgnoreCase(category, pageable)
-                .map(ProductResponseDto::from);
+                .map(ReducedProductResponseDto::from);
     }
 
     public ProductResponseDto getProductDetail(Long productId) {

--- a/backend/src/main/java/com/example/backend/review/model/Review.java
+++ b/backend/src/main/java/com/example/backend/review/model/Review.java
@@ -35,12 +35,12 @@ public class Review {
     @Schema(description = "리뷰 작성 날짜", example = "2025-04-01 14:30:00")
     private LocalDateTime reviewDate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_idx")
     @Schema(description = "리뷰 작성자 유저")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_idx")
     @Schema(description = "리뷰가 작성된 제품")
     private Product product;

--- a/backend/src/main/java/com/example/backend/search/model/ProductIndexDocument.java
+++ b/backend/src/main/java/com/example/backend/search/model/ProductIndexDocument.java
@@ -36,4 +36,6 @@ public class ProductIndexDocument {
     private Double rating;
     @Field(name= "image", type= FieldType.Text)
     private String image;
+    @Field(name= "reviews", type= FieldType.Integer)
+    private Integer reviews;
 }

--- a/backend/src/main/java/com/example/backend/user/model/UserProduct.java
+++ b/backend/src/main/java/com/example/backend/user/model/UserProduct.java
@@ -21,7 +21,7 @@ public class UserProduct {
     @JoinColumn(name = "user_idx")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_idx")
     private Product products;
 }


### PR DESCRIPTION
일부 요소(사용자 제품 연관 테이블, 리뷰 연관 테이블)의 데이터 Fetch type을 Lazy로 명시
제품 목록 API의 응답을 더 작은 형태의 DTO로 반환하도록 변경